### PR TITLE
dialogの導入

### DIFF
--- a/front/src/components/AddScheduleDialog/container.jsx
+++ b/front/src/components/AddScheduleDialog/container.jsx
@@ -1,9 +1,10 @@
-// import React from "react";
-import AddScheduleDialog from "./presentation"
+import AddScheduleDialog from "./presentation";
+
 import { connect } from "react-redux";
+
 import { addScheduleCloseDialog } from "../../redux/addSchedule/actions";
 
-//reduxでのdialogの状態管理を切り替える
+//reduxでdialogの状態管理を切り替え(scheduleだけ受け取る)
 const mapStateToProps = state =>({ schedule:state.addSchedule });
 
 //dialogを閉じるためのメソッド
@@ -13,4 +14,7 @@ const mapDispatchToProps = dispatch =>({
   }
 });
 
-export default connect(mapStateToProps , mapDispatchToProps)(AddScheduleDialog);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+  )(AddScheduleDialog);

--- a/front/src/components/AddScheduleDialog/presentation.jsx
+++ b/front/src/components/AddScheduleDialog/presentation.jsx
@@ -1,9 +1,17 @@
 import React from "react";
 import { Dialog , DialogContent } from "@material-ui/core";
 
-const AddScheduleDialog = ({ schedule:{ isDialogOpen } , closeDialog }) => {
+const AddScheduleDialog = ({ 
+  schedule:{ isDialogOpen },
+  closeDialog
+  }) => {
   return(
-    <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
+    <Dialog 
+      open={isDialogOpen} 
+      onClose={closeDialog} 
+      maxWidth="xs" 
+      fullWidth
+      >
       <DialogContent>
       dialog
       </DialogContent>

--- a/front/src/components/CalendarBoard/container.jsx
+++ b/front/src/components/CalendarBoard/container.jsx
@@ -3,13 +3,13 @@ import CalendarBoard from "./presentation";
 import { createCalendar } from "../../services/calendar";
 import { addScheduleOpenDialog } from "../../redux/addSchedule/actions";
 
-const mapDispatchToProps = dispatch =>({
+const mapStateToProps = state => ({ calendar:state.calendar });
+
+const mapDispatchToProps = dispatch => ({
   openAddScheduleDialog:()=> {
     dispatch(addScheduleOpenDialog());
   }
 });
-
-const mapStateToProps = state => ({calendar:state.calendar});
 
 const mergeProps = (stateProps , dispatchProps ) =>({
   ...stateProps,

--- a/front/src/components/CalendarBoard/presentation.jsx
+++ b/front/src/components/CalendarBoard/presentation.jsx
@@ -3,7 +3,6 @@ import { GridList ,Typography } from '@material-ui/core';
 import CalendarElement from "../CalendarElement";
 import * as styles from "./style.css";
 
-
 const days = ["日","月","火","水","木","金","土",]
 
 const CalendarBoard = ( { calendar , month , openAddScheduleDialog } ) => {
@@ -24,7 +23,10 @@ const CalendarBoard = ( { calendar , month , openAddScheduleDialog } ) => {
           </li>
         ))}
         {calendar.map( c => (
-          <li key={c.toISOString()} onClick={()=>openAddScheduleDialog()}>
+          <li 
+            key={c.toISOString()} 
+            onClick={() => openAddScheduleDialog()}
+          >
             <CalendarElement day={c} month={month} />
           </li>
         ))}

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -1,5 +1,5 @@
-import React from "react";
 import ReactDOM from "react-dom";
+import React from "react";
 import dayjs from "dayjs";
 import "dayjs/locale/ja";
 import { Provider } from "react-redux";

--- a/front/src/redux/addSchedule/actions.js
+++ b/front/src/redux/addSchedule/actions.js
@@ -10,8 +10,9 @@ export const addScheduleSetValue = payload => ({
 });
 
 export const addScheduleOpenDialog = () =>({
-  type:ADD_SCHEDULE_OPEN_DIALOG
+  type:ADD_SCHEDULE_OPEN_DIALOG,
 });
+
 export const addScheduleCloseDialog = () =>({
-  type:ADD_SCHEDULE_CLOSE_DIALOG
+  type:ADD_SCHEDULE_CLOSE_DIALOG,
 });

--- a/front/src/redux/addSchedule/reducer.js
+++ b/front/src/redux/addSchedule/reducer.js
@@ -20,9 +20,9 @@ const addScheduleReducer = (state = init, action) =>{
   switch(type){
     case ADD_SCHEDULE_SET_VALUE:
       return { ...state, form: {...state.form, ...payload} } ;
-    case ADD_SCHEDULE_CLOSE_DIALOG:
-      return {...state, isDialogOpen:true} ;
     case ADD_SCHEDULE_OPEN_DIALOG:
+      return {...state, isDialogOpen:true} ;
+    case ADD_SCHEDULE_CLOSE_DIALOG:
       return init;
     default:
       return state;

--- a/front/src/services/calendar.js
+++ b/front/src/services/calendar.js
@@ -6,7 +6,7 @@ export const createCalendar = month => {
   const firstDayIndex = firstDay.day();
   return Array(35)
   .fill(0)
-  .map((_ ,i) => {
+  .map((_, i) => {
     const diffFormFirstDay = i - firstDayIndex;
     const day = firstDay.add(diffFormFirstDay, "day");
     return day ;


### PR DESCRIPTION
CalenderBoard/presentation.jsxにonClick={()=>openAddScheduleDialog()}を追加
redux/addSchedule/reducer.jsのswitch文内のisDialogOpen:trueを修正